### PR TITLE
Force english mode in webdriver

### DIFF
--- a/scyther_generate_sync_inf.py
+++ b/scyther_generate_sync_inf.py
@@ -102,9 +102,11 @@ def generate_account():
 
         options = uc.ChromeOptions()
         options.add_argument(f'--proxy-server='+proxy)
+        options.add_argument('--lang=en')
 
         #options.add_experimental_option("excludeSwitches", ["enable-automation"])
         #options.add_experimental_option('useAutomationExtension', False)
+        #options.add_experimental_option('prefs', {'intl.accept_languages': 'en,en_US'})
 
         driver = uc.Chrome(options=options, headless=True, user_multi_procs=True, browser_executable_path="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
         #driver = webdriver.Chrome(options=options)


### PR DESCRIPTION
## ISSUE GLOBAL BROWSER LANGAGES
 - You are using a conditional (text) [Yes, it is](https://github.com/sssynk/scyther/blob/main/scyther_generate_sync_inf.py#L145) only for browsers with the US or English language, you must force this so that this is possible globally.

### Set others.. i not know weel you code... but well.

**Note:** _*better uses xpath : more or less this: WebDriverWait(driver, timeout).until(lambda ns: ns.find_element(By.XPATH, '/html/body/div[3]/div[3]/div/button[1]')).click()*_

### Example line 145:
```
try:
    WebDriverWait(driver, 30, ignored_exceptions=[TimeoutException]).until(lambda ns: ns.find_element(By.XPATH, '/html/body/div[3]/div[3]/div/button[1]')).click()
except:
    pass
```

#### NOTE: If you uses a xpath cool not need for browser to by english mode 